### PR TITLE
Adding Http Client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
  - "2.7"
- - "3.2"
  - "3.3"
  - "3.4"
  - "3.5"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ some_metric,host=another-host-001,some_tag=some_value value=123i
 ### HTTP Client
 The default `TelegrafClient` uses UDP to send metrics to Telegraf. The `HttpClient` works similarly, except that it issues requests via an HTTP POST. HTTP introduces non-trivial overhead, so to avoid blocking the main thread, these POSTs are issued in the background.
 
+To use the `HttpClient`, `pytelegraf` must be installed like this: `pip install pytelegraf[http]`. Alternatively, add `pytelegraf[http]` to `requirements.txt`.
+
 ```
 from telegraf import HttpClient
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Will send the following line
 some_metric,host=another-host-001,some_tag=some_value value=123i
 ```
 
+### HTTP Client
+The default `TelegrafClient` uses UDP to send metrics to Telegraf. The `HttpClient` works similarly, except that it issues requests via an HTTP POST. HTTP introduces non-trivial overhead, so to avoid blocking the main thread, these POSTs are issued in the background.
+
+```
+from telegraf import HttpClient
+
+http_client = HttpClient(host='localhost', port=8186)
+http_client.metric('some_metric', 123, tags={'server_name': 'my-server'})
+```
+
 ### Telegraf configuration
 Just follow the sample configuration https://github.com/influxdata/telegraf/tree/master/plugins/inputs/udp_listener
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,3 @@
 mock==2.0.0
 flake8==2.6.0
+requests-futures==0.9.7

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ setup(
     license='MIT',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[
-        'requests-futures==0.9.7'
-    ],
+    extras_require={
+        'http': ['requests-futures==0.9.7']
+    },
     test_suite='telegraf.tests',
     classifiers=[
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,16 @@ from setuptools import find_packages, setup
 
 setup(
     name='pytelegraf',
-    version='0.1.1',
+    version='0.2.0',
     description='Telegraf client',
     author='paksu',
     url='https://github.com/paksu/pytelegraf',
     license='MIT',
     packages=find_packages(),
     include_package_data=True,
+    install_requires=[
+        'requests-futures==0.9.7'
+    ],
     test_suite='telegraf.tests',
     classifiers=[
         'Environment :: Web Environment',

--- a/telegraf/__init__.py
+++ b/telegraf/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-from .client import TelegrafClient
+from .client import TelegrafClient, HttpClient
 
 VERSION = (0, 1, 1)
 __version__ = '.'.join(map(str, VERSION))
-__all__ = ['TelegrafClient']
+__all__ = ['TelegrafClient', 'HttpClient']

--- a/telegraf/client.py
+++ b/telegraf/client.py
@@ -1,6 +1,5 @@
 from abc import abstractmethod
 from telegraf.protocol import Line
-from requests_futures.sessions import FuturesSession
 import socket
 
 
@@ -56,6 +55,13 @@ class TelegrafClient(ClientBase):
 class HttpClient(ClientBase):
 
     def __init__(self, host='localhost', port=8094, tags=None):
+        # only import HttpClient's dependencies if using HttpClient
+        # if they're not found, inform the user how to install them
+        try:
+            from requests_futures.sessions import FuturesSession
+        except ImportError:
+            raise ImportError('pytelegraf[http] must be installed to use HTTP transport')
+
         super(HttpClient, self).__init__(host, port, tags)
 
         # the default url path for writing metrics to Telegraf is /write


### PR DESCRIPTION
I have a need to use HTTP instead of UDP (or TCP) for emitting metrics to Telegraf. This introduces an HTTP client to communicate with Telegraf. It issues the HTTP requests in a separate thread to avoid blocking the main thread.

I tested in both Python 2.7 and Python 3.5. 