### PR TITLE
Allow zero values

### DIFF
--- a/telegraf/client.py
+++ b/telegraf/client.py
@@ -15,7 +15,7 @@ class ClientBase(object):
         Append global tags configured for the client to the tags given then
         converts the data into InfluxDB Line protocol and sends to to socket
         """
-        if not measurement_name or not values:
+        if not measurement_name or values in (None, {}):
             # Don't try to send empty data
             return
 

--- a/telegraf/protocol.py
+++ b/telegraf/protocol.py
@@ -4,7 +4,7 @@ from telegraf.utils import format_string, format_value
 class Line(object):
     def __init__(self, measurement, values, tags={}, timestamp=None):
         assert measurement, "Must have measurement"
-        assert values, "Must have values"
+        assert values not in (None, {}), "Must have values"
 
         # Name of the actual measurement
         self.measurement = measurement
@@ -37,6 +37,9 @@ class Line(object):
 
         # Sort the values in lexicographically by value name
         sorted_values = sorted(metric_values.items())
+
+        # Remove None values
+        sorted_values = [(k, v) for k, v in sorted_values if v is not None]
 
         return ",".join("{0}={1}".format(format_string(k), format_value(v)) for k, v in sorted_values)
 

--- a/telegraf/tests.py
+++ b/telegraf/tests.py
@@ -1,4 +1,4 @@
-from telegraf.client import TelegrafClient, HttpClient
+from telegraf.client import ClientBase, TelegrafClient, HttpClient
 from telegraf.protocol import Line
 from telegraf.utils import format_string, format_value
 import unittest
@@ -85,6 +85,33 @@ class TestLine(unittest.TestCase):
             Line('some_series', {'a': 1, 'baa': 1, 'AAA': 1, 'aaa': 1}).to_line_protocol(),
             'some_series AAA=1i,a=1i,aaa=1i,baa=1i'
         )
+
+
+class TestClientBase(unittest.TestCase):
+
+    def test_zero_value(self):
+        self.client = ClientBase()
+        self.client.send = mock.Mock()
+        self.client.metric('some_series', 0)
+        self.client.send.assert_called_with('some_series value=0i')
+
+    def test_null_value(self):
+        self.client = ClientBase()
+        self.client.send = mock.Mock()
+        self.client.metric('some_series', None)
+        self.assertEqual(self.client.send.call_count, 0)
+
+    def test_empty_values_dict(self):
+        self.client = ClientBase()
+        self.client.send = mock.Mock()
+        self.client.metric('some_series', {})
+        self.assertEqual(self.client.send.call_count, 0)
+
+    def test_some_zero_values(self):
+        self.client = ClientBase()
+        self.client.send = mock.Mock()
+        self.client.metric('some_series', {'value_one': 1, 'value_zero': 0, 'value_none': None})
+        self.client.send.assert_called_with('some_series value_one=1i,value_zero=0i')
 
 
 class TestTelegraf(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -7,3 +7,4 @@ commands=discover
 deps =
   discover
   mock
+  requests-futures


### PR DESCRIPTION
Fixes a bug in ClientBase.metric() that prevented a values of 0 (zero) to be sent to telegraf. Also removes None values from multi-value dicts because they're not supported in InfluxDB line protocol.