### PR TITLE
Encode line protocol to UTF8

### DIFF
--- a/telegraf/client.py
+++ b/telegraf/client.py
@@ -46,7 +46,7 @@ class TelegrafClient(ClientBase):
         Sends the given data to the socket via UDP
         """
         try:
-            self.socket.sendto(data.encode('ascii') + b'\n', (self.host, self.port))
+            self.socket.sendto(data.encode('utf8') + b'\n', (self.host, self.port))
         except (socket.error, RuntimeError):
             # Socket errors should fail silently so they don't affect anything else
             pass

--- a/telegraf/client.py
+++ b/telegraf/client.py
@@ -15,7 +15,7 @@ class ClientBase(object):
         Append global tags configured for the client to the tags given then
         converts the data into InfluxDB Line protocol and sends to to socket
         """
-        if not measurement_name or not values:
+        if not measurement_name or values in (None, {}):
             # Don't try to send empty data
             return
 

--- a/telegraf/protocol.py
+++ b/telegraf/protocol.py
@@ -38,7 +38,7 @@ class Line(object):
         # Sort the values in lexicographically by value name
         sorted_values = sorted(metric_values.items())
 
-        return ",".join("{0}={1}".format(format_string(k), format_value(v)) for k, v in sorted_values)
+        return u",".join(u"{0}={1}".format(format_string(k), format_value(v)) for k, v in sorted_values)
 
     def get_output_tags(self):
         """
@@ -52,7 +52,7 @@ class Line(object):
         sorted_tags = sorted(self.tags.items())
 
         # Finally render, escape and return the tag string
-        return ",".join("{0}={1}".format(format_string(k), format_string(v)) for k, v in sorted_tags)
+        return u",".join(u"{0}={1}".format(format_string(k), format_string(v)) for k, v in sorted_tags)
 
     def get_output_timestamp(self):
         """
@@ -66,7 +66,7 @@ class Line(object):
         """
         tags = self.get_output_tags()
 
-        return "{0}{1} {2}{3}".format(
+        return u"{0}{1} {2}{3}".format(
             self.get_output_measurement(),
             "," + tags if tags else '',
             self.get_output_values(),

--- a/telegraf/protocol.py
+++ b/telegraf/protocol.py
@@ -4,7 +4,7 @@ from telegraf.utils import format_string, format_value
 class Line(object):
     def __init__(self, measurement, values, tags={}, timestamp=None):
         assert measurement, "Must have measurement"
-        assert values, "Must have values"
+        assert values not in (None, {}), "Must have values"
 
         # Name of the actual measurement
         self.measurement = measurement
@@ -37,6 +37,9 @@ class Line(object):
 
         # Sort the values in lexicographically by value name
         sorted_values = sorted(metric_values.items())
+
+        # Remove None values
+        sorted_values = [(k, v) for k, v in sorted_values if v is not None]
 
         return ",".join("{0}={1}".format(format_string(k), format_value(v)) for k, v in sorted_values)
 

--- a/telegraf/tests.py
+++ b/telegraf/tests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from telegraf.client import TelegrafClient, HttpClient
 from telegraf.protocol import Line
 from telegraf.utils import format_string, format_value
@@ -111,6 +113,14 @@ class TestTelegraf(unittest.TestCase):
 
         self.client.metric('some_series', 1, tags={'host': 'override-host-tag'})
         self.client.socket.sendto.assert_called_with(b'some_series,host=override-host-tag value=1i\n', self.addr)
+
+    def test_utf8_encoding(self):
+        self.client = TelegrafClient(self.host, self.port)
+        self.client.socket = mock.Mock()
+
+        self.client.metric(u'meäsurement', values={u'välue': 1, u'këy': u'valüe'}, tags={u'äpples': u'öranges'})
+        self.client.socket.sendto.assert_called_with(
+            b'me\xc3\xa4surement,\xc3\xa4pples=\xc3\xb6ranges k\xc3\xaby="val\xc3\xbce",v\xc3\xa4lue=1i\n', self.addr)
 
 
 class TestTelegrafHttp(unittest.TestCase):

--- a/telegraf/tests.py
+++ b/telegraf/tests.py
@@ -1,4 +1,4 @@
-from telegraf.client import TelegrafClient, HttpClient
+from telegraf.client import ClientBase, TelegrafClient, HttpClient
 from telegraf.protocol import Line
 from telegraf.utils import format_string, format_value
 import unittest
@@ -85,6 +85,33 @@ class TestLine(unittest.TestCase):
             Line('some_series', {'a': 1, 'baa': 1, 'AAA': 1, 'aaa': 1}).to_line_protocol(),
             'some_series AAA=1i,a=1i,aaa=1i,baa=1i'
         )
+
+
+class TestClientBase(unittest.TestCase):
+
+    def test_zero_value(self):
+        self.client = ClientBase()
+        self.client.send = mock.Mock()
+        self.client.metric('some_series', 0)
+        self.client.send.assert_called_with('some_series value=0i')
+
+    def test_null_value(self):
+        self.client = ClientBase()
+        self.client.send = mock.Mock()
+        self.client.metric('some_series', None)
+        self.assertEqual(self.client.send.call_count, 0)
+
+    def test_empty_values_dict(self):
+        self.client = ClientBase()
+        self.client.send = mock.Mock()
+        self.client.metric('some_series', {})
+        self.assertEqual(self.client.send.call_count, 0)
+
+    def test_some_zero_values(self):
+        self.client = ClientBase()
+        self.client.send = mock.Mock()
+        self.client.metric('some_series', {'value_one': 1, 'value_zero': 0, 'value_none': None})
+        self.client.send.assert_called_with('some_series value_one=1i,value_zero=0i')
 
 
 class TestTelegraf(unittest.TestCase):

--- a/telegraf/utils.py
+++ b/telegraf/utils.py
@@ -36,7 +36,7 @@ def format_value(value):
     """
     if isinstance(value, basestring):
         value = value.replace('"', '\"')
-        value = '"{0}"'.format(value)
+        value = u'"{0}"'.format(value)
     elif isinstance(value, bool):
         value = str(value)
     elif isinstance(value, int):

--- a/tox.ini
+++ b/tox.ini
@@ -7,3 +7,4 @@ commands=discover
 deps =
   discover
   mock
+  requests-futures


### PR DESCRIPTION
Encode line protocol to UTF8, make sure unicode (python 2) / str (python 3) with non-ASCII characters can be used in all places that allow it (measurement names, tag keys/values, field keys/values)

I'm pretty confident this change does not break existing usage of pytelegraf. Previously, using any non-ASCII data in either str/unicode/bytes data type would either crash in format_value or at last in TelegrafClient.send where an attempt to encode it to ASCII was made. 