### PR TITLE
Fix equal signs escaping

### DIFF
--- a/telegraf/tests.py
+++ b/telegraf/tests.py
@@ -14,6 +14,7 @@ class TestLine(unittest.TestCase):
         self.assertEquals(format_string('foo,bar'), 'foo\,bar')
         self.assertEquals(format_string('foo bar'), 'foo\ bar')
         self.assertEquals(format_string('foo ,bar'), 'foo\ \,bar')
+        self.assertEquals(format_string('foo ,bar,baz=foobar'), 'foo\ \,bar\,baz\=foobar')
 
     def test_format_value(self):
         self.assertEquals(format_value('foo'), '"foo"')

--- a/telegraf/utils.py
+++ b/telegraf/utils.py
@@ -10,13 +10,15 @@ def format_string(key):
     Formats either measurement names, tag names or tag values.
 
     Measurement name and any optional tags separated by commas. Measurement names, tag keys,
-    and tag values must escape any spaces or commas using a backslash (\). For example: \ and \,.
+    and tag values must escape any spaces, commas or equal signs using a backslash (\).
+    For example: \ and \,.
 
     All tag values are stored as strings and should not be surrounded in quotes.
     """
     if isinstance(key, basestring):
         key = key.replace(",", "\,")
         key = key.replace(" ", "\ ")
+        key = key.replace("=", "\=")
     return key
 
 


### PR DESCRIPTION
According to InfluxDB line protocol documentation,
equal signs must be escaped as well as commas and spaces.
Otherwise it causes invalid tag format error when trying
to send tag containing one or more equal signs.
Link:
[https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_reference/#special-characters](https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_reference/#special-characters)