### PR TITLE
Define package version only in one place

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,18 @@
+import os
+
 from setuptools import find_packages, setup
 
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+about = {}
+with open(os.path.join(here, 'telegraf', '__version__.py'), 'r') as f:
+    exec(f.read(), about)
+
 setup(
-    name='pytelegraf',
-    version='0.3.2',
-    description='Telegraf client',
+    name=about['__title__'],
+    version=about['__version__'],
+    description=about['__description__'],
     author='paksu',
     url='https://github.com/paksu/pytelegraf',
     license='MIT',

--- a/telegraf/__init__.py
+++ b/telegraf/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
+from .__version__ import __title__, __description__, __version__  # noqa
 from .client import TelegrafClient, HttpClient
 
-VERSION = (0, 1, 1)
-__version__ = '.'.join(map(str, VERSION))
-__all__ = ['TelegrafClient', 'HttpClient']
+__all__ = ('TelegrafClient', 'HttpClient')

--- a/telegraf/__version__.py
+++ b/telegraf/__version__.py
@@ -1,0 +1,3 @@
+__title__ = 'pytelegraf'
+__description__ = 'Telegraf client'
+__version__ = '0.3.2'


### PR DESCRIPTION
Hi!

I found, that package version has been updated only in `setup.py`, but missed in `telegraf/__init__.py`.
I think, it's better to have only one place to define version.
I looked at `requests` package and propose to use the same schema.