### PR TITLE
Add a context manager and decorator for timing metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ client.metric('some_metric', {'value_a': 100, 'value_b': 100, 'value_c': True})
 
 # Records a single value with one tag
 client.metric('some_metric', 123, tags={'server_name': 'my-server'})
+
+# Times a function call. The measurement name defaults to __module__.__func__
+@client.timer('some_metric', tags={'server_name':'my-server'})
+def some_operation():
+    pass
+
+# Uses a context manager to time an operation
+with client.timer('some_metric'):
+    time.sleep(2)
+
+# As above, but time in milliseconds
+with client.timer('some_metric', use_ms=True):
+    time.sleep(2)
 ```
 
 #### Global tags

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ import os
 
 from setuptools import find_packages, setup
 
-
 here = os.path.abspath(os.path.dirname(__file__))
 
 about = {}

--- a/telegraf/__init__.py
+++ b/telegraf/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from .__version__ import __title__, __description__, __version__  # noqa
-from .client import TelegrafClient, HttpClient
+from .__version__ import __description__, __title__, __version__  # noqa
+from .client import HttpClient, TelegrafClient
 
 __all__ = ('TelegrafClient', 'HttpClient')

--- a/telegraf/context.py
+++ b/telegraf/context.py
@@ -11,7 +11,7 @@ from time import time
 def wrapped_coroutine(self, func):
     """Timing wrapper for async functions."""
     @wraps(func)
-    async def wrapped_co(*args, **kwargs):
+    async def wrapped_co(*args, **kwargs):  # noqa E999
         start = time()
         try:
             return await func(*args, **kwargs)

--- a/telegraf/context.py
+++ b/telegraf/context.py
@@ -1,0 +1,20 @@
+"""
+Decorator for async methods.
+
+Requires Python 3.5 or higher.
+"""
+# stdlib
+from functools import wraps
+from time import time
+
+
+def wrapped_coroutine(self, func):
+    """Timing wrapper for async functions."""
+    @wraps(func)
+    async def wrapped_co(*args, **kwargs):
+        start = time()
+        try:
+            return await func(*args, **kwargs)
+        finally:
+            self._send(start)
+    return wrapped_co

--- a/telegraf/context.py
+++ b/telegraf/context.py
@@ -11,7 +11,7 @@ from time import time
 def wrapped_coroutine(self, func):
     """Timing wrapper for async functions."""
     @wraps(func)
-    async def wrapped_co(*args, **kwargs):  # noqa E999
+    async def wrapped_co(*args, **kwargs):  # noqa
         start = time()
         try:
             return await func(*args, **kwargs)

--- a/telegraf/defaults/django.py
+++ b/telegraf/defaults/django.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import
-from django.conf import settings
 
+from django.conf import settings
 from telegraf import defaults
 from telegraf.client import TelegrafClient
-
 
 telegraf = None
 

--- a/telegraf/tests.py
+++ b/telegraf/tests.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from telegraf.client import ClientBase, TelegrafClient, HttpClient
+import unittest
+
+import mock
+from telegraf.client import ClientBase, HttpClient, TelegrafClient
 from telegraf.protocol import Line
 from telegraf.utils import format_string, format_value
-import unittest
-import mock
 
 
 class TestLine(unittest.TestCase):

--- a/telegraf/utils.py
+++ b/telegraf/utils.py
@@ -1,3 +1,5 @@
+import sys
+
 try:
     basestring
 except NameError:
@@ -46,3 +48,8 @@ def format_value(value):
     elif isinstance(value, float):
         value = str(value)
     return value
+
+
+def is_higher_py35():
+    """Check that the Python is version 3.5 or higher."""
+    return sys.version_info >= (3, 5)


### PR DESCRIPTION
Allows the use of

    with client.timer('some_metric'):
        <some code>

    with client.timer('some_metric', use_ms=True):
        <some code>

    @client.timer('some_metric', use_ms=True)
    def my_function():
        pass